### PR TITLE
SPI pins are fixed

### DIFF
--- a/GNC255/Community/boards/mobiflight_GNC255_mega.board.json
+++ b/GNC255/Community/boards/mobiflight_GNC255_mega.board.json
@@ -359,24 +359,6 @@
       "isAnalog": false,
       "isI2C": false,
       "isPWM": false,
-      "Pin": 50
-    },
-    {
-      "isAnalog": false,
-      "isI2C": false,
-      "isPWM": false,
-      "Pin": 51
-    },
-    {
-      "isAnalog": false,
-      "isI2C": false,
-      "isPWM": false,
-      "Pin": 52
-    },
-    {
-      "isAnalog": false,
-      "isI2C": false,
-      "isPWM": false,
       "Pin": 53
     },
     {

--- a/GNC255/Community/boards/mobiflight_GNC255_pico.board.json
+++ b/GNC255/Community/boards/mobiflight_GNC255_pico.board.json
@@ -149,25 +149,7 @@
         "isAnalog": false,
         "isI2C": false,
         "isPWM": true,
-        "Pin": 16
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": true,
         "Pin": 17
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": true,
-        "Pin": 18
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": true,
-        "Pin": 19
       },
       {
         "isAnalog": false,

--- a/GNC255/Community/devices/mobiflight.gnc255.device.json
+++ b/GNC255/Community/devices/mobiflight.gnc255.device.json
@@ -9,8 +9,6 @@
   },
   "Config": {
     "Pins": [
-      "CLK",
-      "Data",
       "CS",
       "D/C",
       "Reset"

--- a/GNC255/MFCustomDevice.cpp
+++ b/GNC255/MFCustomDevice.cpp
@@ -93,10 +93,6 @@ void MFCustomDevice::attach(int16_t adrPin, uint16_t adrType, uint16_t adrConfig
         multiple devices, it is done here.
     ********************************************************************************************** */
     params = strtok_r(parameter, "|", &p);
-    _clk   = atoi(params);
-    params = strtok_r(NULL, "|", &p);
-    _data  = atoi(params);
-    params = strtok_r(NULL, "|", &p);
     _cs    = atoi(params);
     params = strtok_r(NULL, "|", &p);
     _dc    = atoi(params);

--- a/README.md
+++ b/README.md
@@ -14,9 +14,13 @@ Pico
 * Data: Pin 19
 * CS: Pin 17 for the first display, for more choose as you want
 * Pin 16 can NOT be used for any other device
+
 For both boards D/C and Reset can be choosen as you want.
 
-For now these pins have to be defined within the connector to mark them as used. This will be changed later.
+** Important Remark **
+If you have already used this before, delete your config from the board before updating!
+Once you have updated your board configure the display agin. CLK and Data pins must not be configured anymore as they are fixed (as before).
+Also make sure to use the updated `mobiflight.gnc255.device.json` file.
 
 Connect your display accordingly the above used pins. Depending on your display, you might need to adjust some 
 jumpers on the controller board to enable the SPI interface - below is one example of such display that works


### PR DESCRIPTION
## Description of changes

This display uses the hardware SPI interface, so two pins are fixed and cannot be chosen within the configuration as before.
CLK, MOSI and MISO are deleted from the board.json files.
CLK and Data are deleted from the device.json as they don't need to be configured anymore.
Readme file is updated accordingly.
