### PR TITLE
Nano board as example added

### DIFF
--- a/GNC255/Community/boards/mobiflight_GNC255_mega.board.json
+++ b/GNC255/Community/boards/mobiflight_GNC255_mega.board.json
@@ -37,7 +37,7 @@
     "DelayAfterFirmwareUpdate": 0,
     "FirmwareBaseName": "mobiflight_gnc255_mega",
     "FirmwareExtension": "hex",
-    "LatestFirmwareVersion": "2.5.0",
+    "LatestFirmwareVersion": "2.5.1",
     "FriendlyName": "MobiFlight GNC255 Mega",
     "MobiFlightType": "MobiFlight GNC255 Mega",
     "MobiFlightTypeLabel": "MobiFlight GNC255 Mega",

--- a/GNC255/Community/boards/mobiflight_GNC255_nano.board.json
+++ b/GNC255/Community/boards/mobiflight_GNC255_nano.board.json
@@ -1,0 +1,194 @@
+{
+  "$schema": "./mfboard.schema.json",
+  "AvrDudeSettings": {
+    "Attempts": 1,
+    "Device": "atmega328p",
+    "BaudRates": ["115200", "57600"],
+    "Programmer": "arduino",
+    "Timeout": 20000
+  },
+  "Connection": {
+    "ConnectionDelay": 1750,
+    "DelayAfterFirmwareUpdate": 0,
+    "DtrEnable": true,
+    "EEPROMSize": 286,
+    "ExtraConnectionRetry": true,
+    "ForceResetOnFirmwareUpdate": false,
+    "MessageSize": 64,
+    "TimeoutForFirmwareUpdate": 60000
+  },
+  "HardwareIds": [
+    "^VID_2341&PID_0043",
+    "^VID_2A03&PID_0043",
+    "^VID_2341&PID_0243",
+    "^VID_2341&PID_0001",
+    "^VID_1A86&PID_7523",
+    "^VID_0403&PID_6001",
+    "^VID_067B&PID_2303",
+    "^VID_0403\\+PID_6001\\+.+"
+  ],
+  "Info": {
+    "CanInstallFirmware": true,
+    "CanResetBoard": true,
+    "FirmwareBaseName": "mobiflight_gnc255_nano",
+    "FirmwareExtension": "hex",
+    "FriendlyName": "Arduino GNC255 Nano",
+    "LatestFirmwareVersion": "2.5.1",
+    "MobiFlightType": "MobiFlight Template Nano",
+    "MobiFlightTypeLabel": "MobiFlight GNC255 Nano",
+    "ResetFirmwareFile": "reset.arduino_uno_1_0_2.hex",
+    "CustomDeviceTypes": [
+      "MOBIFLIGHT_GNC255"
+    ],
+    "Community": {
+      "Project": "Mobiflight GNC255",
+      "Website": "https://github.com/MobiFlight/MobiFlight-CustomDevices/tree/main/Mobiflight/GNC255",
+      "Docs": "https://github.com/MobiFlight/MobiFlight-Connector/wiki",
+      "Support": "https://mobiflight.com/discord"
+    }
+  },
+  "ModuleLimits": {
+    "MaxAnalogInputs": 8,
+    "MaxButtons": 18,
+    "MaxEncoders": 9,
+    "MaxInputShifters": 6,
+    "MaxLcdI2C": 2,
+    "MaxLedSegments": 6,
+    "MaxOutputs": 18,
+    "MaxServos": 8,
+    "MaxShifters": 6,
+    "MaxSteppers": 4,
+    "MaxInputMultiplexer": 6,
+    "MaxCustomDevices": 0
+  },
+  "Pins": [
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 2
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 3
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 4
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 5
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 6
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 7
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 8
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 9
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 10
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 11
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 12
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 13
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Name": "A0",
+      "Pin": 14
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Name": "A1",
+      "Pin": 15
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Name": "A2",
+      "Pin": 16
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Name": "A3",
+      "Pin": 17
+    },
+    {
+      "isAnalog": true,
+      "isI2C": true,
+      "isPWM": false,
+      "Name": "A4",
+      "Pin": 18
+    },
+    {
+      "isAnalog": true,
+      "isI2C": true,
+      "isPWM": false,
+      "Name": "A5",
+      "Pin": 19
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Name": "A6",
+      "Pin": 20
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Name": "A7",
+      "Pin": 21
+    }
+  ]
+}

--- a/GNC255/Community/boards/mobiflight_GNC255_pico.board.json
+++ b/GNC255/Community/boards/mobiflight_GNC255_pico.board.json
@@ -20,7 +20,7 @@
     "FirmwareBaseName": "mobiflight_gnc255_raspberrypico",
     "FirmwareExtension": "uf2",
     "FriendlyName": "MobiFlight GNC255 Pico",
-    "LatestFirmwareVersion": "2.5.0",
+    "LatestFirmwareVersion": "2.5.1",
     "MobiFlightType": "MobiFlight GNC255 Pico",
     "MobiFlightTypeLabel": "MobiFlight GNC255 Pico",
     "ResetFirmwareFile": "reset.raspberry_pico_flash_nuke.uf2",

--- a/GNC255/GNC255_platformio.ini
+++ b/GNC255/GNC255_platformio.ini
@@ -42,6 +42,33 @@ custom_community_project = ${env_gnc255.custom_community_project}			; don't chan
 custom_device_folder = ${env_gnc255.custom_device_folder}					; don't change this one!
 
 
+; Build settings for the Arduino Nano with GNC255 support
+[env:gnc255_nano]
+platform = atmelavr
+board = nanoatmega328
+framework = arduino
+build_flags = 
+	${env_gnc255.build_flags}										; don't change this one!
+	-DMF_LCD_SUPPORT=0												; disable LCD support, otherise Flash will be exceeded
+	-DMF_STEPPER_SUPPORT=0											; disable Stepper support, otherise Flash will be exceeded
+	-I./src/_Boards/Atmel/Board_Nano								; Include the required board definition. If you need your own definition, adapt this to your path (e.g. -I./CustomDevices/_template/_Boards)
+	'-DMOBIFLIGHT_TYPE="Mobiflight GNC255 Nano"'					; this must match with "MobiFlightType" within the .json file
+	'-DMOBIFLIGHT_NAME="Mobiflight GNC255"' 						; this will show up as Name in the settings dialog unless it gets change from there
+build_src_filter = 
+	${env.build_src_filter}											; don't change this one!
+	${env_gnc255.build_src_filter}									; don't change this one!
+lib_deps = 
+	${env.lib_deps}													; don't change this one!
+	${env.custom_lib_deps_Atmel}									; don't change this one!
+	${env_gnc255.lib_deps}											; don't change this one!
+monitor_speed = 115200												; don't change this one!
+extra_scripts = 
+	${env.extra_scripts}											; don't change this one!
+custom_core_firmware_version = ${env_gnc255.custom_core_firmware_version}	; don't change this one!
+custom_community_project = ${env_gnc255.custom_community_project}			; don't change this one!
+custom_device_folder = ${env_gnc255.custom_device_folder}	
+
+
 ; Build settings for the Raspberry Pico with GNC255 support
 [env:gnc255_raspberrypico]
 platform = https://github.com/maxgerhardt/platform-raspberrypi.git


### PR DESCRIPTION
## Description of changes

In GNC255_platformio.ini the Nano Board is added as an additional example. To fit the GNC255 support into Flash, Stepper and LCD support has to be deactivated.

Json Files for Mega and Pico updated to version 2.5.1 as already in GNC255_platformio.ini