### PR TITLE
added setContrast method for the GNC255 oled device (recreated PR)

### DIFF
--- a/GNC255/GNC255.cpp
+++ b/GNC255/GNC255.cpp
@@ -110,6 +110,9 @@ void GNC255::set(int16_t messageID, const char *data)
     case 5: // set COM/NAV mode
         setMode(strcmp(data, "0") == 0);
         break;
+    case 6: // set contrast (brightness) of OLED
+        setContrast(atoi(data));
+        break;
     default:
         break;
     }
@@ -164,4 +167,9 @@ void GNC255::_renderLabel(const char *text, Label label, Position offset, bool u
 
     _oledDisplay->print(text);
     if (update) _oledDisplay->sendBuffer();
+}
+
+void GNC255::setContrast(uint8_t displayContrast)
+{
+    _oledDisplay->setContrast(displayContrast);
 }

--- a/GNC255/GNC255.h
+++ b/GNC255/GNC255.h
@@ -44,6 +44,7 @@ private:
     bool                                 _hasChanged;
     char                                 activeFrequency[8]  = "123.456";
     char                                 standbyFrequency[8] = "123.456";
+    uint8_t                              displayContrast = 32;
 
     void _update();
     void _stop();
@@ -53,4 +54,5 @@ private:
     void updateActiveLabel(const char *frequency);
     void updateStandbyLabel(const char *frequency);
     void _renderLabel(const char *text, Label label, Position offset, bool update = false);
+    void setContrast(uint8_t displayContrast);
 };


### PR DESCRIPTION
## Description of changes

Fixes #9 

The Contrast setting PR got lost in the repo reorg apparently, so I recreated it.
It seems to work OK, (tested on RP2040 and Mega), so I made a new PR.

The device json file change was already in.

And yes, "contrast" is really Brightness on an OLED, so it is shown to the user as "brightness" (device json) but the code says Contrast, because that's what the lcd library function is called.