### PR TITLE
Shift everything 6 pixels to the right, to align better on screen

### DIFF
--- a/GNC255/GNC255.cpp
+++ b/GNC255/GNC255.cpp
@@ -12,11 +12,11 @@ Layout ComLayout = {
 };
 
 Position OffsetActive = {
-    0,
+    6,
     0};
 
 Position OffsetStandby = {
-    140,
+    146,
     0};
 
 GNC255::GNC255(uint8_t clk, uint8_t data, uint8_t cs, uint8_t dc, uint8_t reset)


### PR DESCRIPTION
## Description of changes

Fixes #13 

Changed the layout offsets of Active and Standby by 6 pixels to right - everything seems to fit still. The text labels will now have slightly less space, but that is understandable.